### PR TITLE
Updated String Copy

### DIFF
--- a/Source Code_Dynamic
+++ b/Source Code_Dynamic
@@ -40,7 +40,7 @@ void main()
 	cout << "Enter the query. \n";
 	cin.getline(s, 100);
 	cout << "\n";
-	lstrcpy((char *)query, s);
+	strcpy_s((char *)query,100, s);
 	SQLExecDirect(hstmt, query, SQL_NTS);
 
 	//7.Fetch Data


### PR DESCRIPTION
Used **strcpy_s()**, which is a stable version of **strcpy()** due to the presence buffer size in the statement.